### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 このMCPサーバーは、EVE Onlineのマーケットデータにアクセスするためのインターフェースを提供します。ESI（EVE Swagger Interface）APIを使用して、リアルタイムの市場データを取得できます。
 
+<a href="https://glama.ai/mcp/servers/@kongyo2/eve-online-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kongyo2/eve-online-mcp/badge" alt="eve-online-mcp MCP server" />
+</a>
+
 ## 認証とレート制限
 
 このサーバーは現在、パブリックなマーケットデータのみを取得するため、ESI認証は必要ありません。ただし、以下の制限と仕様があります：


### PR DESCRIPTION
This PR adds a badge for the [eve-online-mcp](https://glama.ai/mcp/servers/@kongyo2/eve-online-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kongyo2/eve-online-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kongyo2/eve-online-mcp/badge" alt="eve-online-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.